### PR TITLE
ArchLinux ARM package

### DIFF
--- a/board/olimex/a10_olinuxino/board.c
+++ b/board/olimex/a10_olinuxino/board.c
@@ -51,7 +51,14 @@ int show_board_info(void)
 #ifdef CONFIG_BOARD_LATE_INIT
 int board_late_init(void)
 {
-	/*No need to late init*/
+	int pin;
+
+	pin = sunxi_name_to_gpio("PC3");
+
+	gpio_request(pin, "satapwr");
+	gpio_direction_output(pin, 1);
+	/* Give attached sata device time to power-up to avoid link timeouts */
+	mdelay(500);
 
 	return 0;
 }
@@ -69,19 +76,19 @@ int board_fit_config_name_match(const char *name)
 #ifdef CONFIG_ENV_IS_IN_EXT4
 const char *env_ext4_get_dev_part(void)
 {
-		return "0:auto";
+	return "0:auto";
 }
 #endif /* CONFIG_ENV_IS_IN_EXT4 */
 
 #ifdef CONFIG_ENV_IS_IN_FAT
 const char *env_fat_get_dev_part(void)
 {
-			return "0:auto";
-	
+	return "0:auto";
 }
 #endif /* CONFIG_ENV_IS_IN_FAT */
 
-#if CONFIG_ENV_IS_IN_SPI_FLASH
+#ifdef CONFIG_ENV_IS_IN_SPI_FLASH
+#if defined(CONFIG_ENV_IS_IN_EXT4) && defined(CONFIG_ENV_IS_IN_FAT)
 static enum env_location env_get_location_spi(int prio)
 {
 	switch (prio) {
@@ -97,7 +104,6 @@ static enum env_location env_get_location_spi(int prio)
 
 	return ENVL_UNKNOWN;
 }
-#endif
 
 static enum env_location env_get_location_default(int prio)
 {
@@ -112,6 +118,17 @@ static enum env_location env_get_location_default(int prio)
 
 	return ENVL_UNKNOWN;
 }
+#else
+static enum env_location env_get_location_spi(int __maybe_unused prio)
+{
+	return ENVL_SPI_FLASH;
+}
+
+static enum env_location env_get_location_default(int __maybe_unused prio)
+{
+	return ENVL_NOWHERE;
+}
+#endif
 
 enum env_location env_get_location(enum env_operation op, int prio)
 {
@@ -119,17 +136,13 @@ enum env_location env_get_location(enum env_operation op, int prio)
 
 	switch (boot) {
 	case BOOT_DEVICE_BOARD:
-#ifdef CONFIG_ENV_IS_IN_SPI_FLASH
 		if (olinuxino_board_has_spi())
 			return env_get_location_spi(prio);
 		else
-#endif
 			return env_get_location_default(prio);
 
-#ifdef CONFIG_ENV_IS_IN_SPI_FLASH
 	case BOOT_DEVICE_SPI:
 		return env_get_location_spi(prio);
-#endif
 
 	case BOOT_DEVICE_MMC1:
 	case BOOT_DEVICE_MMC2:
@@ -142,3 +155,19 @@ enum env_location env_get_location(enum env_operation op, int prio)
 
 	return env_get_location_default(prio);
 }
+
+#elif defined(CONFIG_ENV_IS_IN_EXT4) && defined(CONFIG_ENV_IS_IN_FAT)
+enum env_location env_get_location(enum env_operation op, int prio)
+{
+	switch (prio) {
+	case 0:
+		return ENVL_EXT4;
+	case 1:
+		return ENVL_FAT;
+	default:
+		break;
+	}
+
+	return ENVL_UNKNOWN;
+}
+#endif

--- a/board/olimex/a10_olinuxino/board.c
+++ b/board/olimex/a10_olinuxino/board.c
@@ -25,10 +25,10 @@ void spl_board_init(void)
 {
 	printf("A10-Lime Board no eeprom found!\n ");
 	
-		eeprom->header = OLINUXINO_EEPROM_MAGIC;
-		eeprom->id = 9999;
-		eeprom->revision.major = 'A';
-		eeprom->revision.minor = 0;
+	eeprom->header = OLINUXINO_EEPROM_MAGIC;
+	eeprom->id = 9999;
+	eeprom->revision.major = 'A';
+	eeprom->revision.minor = 0;
 
 }
 #endif /* CONFIG_SPL_BUILD */
@@ -36,17 +36,14 @@ void spl_board_init(void)
 #ifdef CONFIG_DISPLAY_BOARDINFO
 int show_board_info(void)
 {
-	char  rev[3];
 	const char *name;
 
 	name = olinuxino_get_board_name();
-
-	olinuxino_get_board_revision(rev);
-	printf("%-7s%s Rev.%s", "ID:", name, rev);
+	printf("%-7s%s\n", "ID:", name);
 
 	return 0;
 }
-#endif
+#endif /* CONFIG_DISPLAY_BOARDINFO */
 
 #ifdef CONFIG_BOARD_LATE_INIT
 int board_late_init(void)
@@ -54,6 +51,7 @@ int board_late_init(void)
 	int pin;
 
 	pin = sunxi_name_to_gpio("PC3");
+	if (pin<=0) return 0;
 
 	gpio_request(pin, "satapwr");
 	gpio_direction_output(pin, 1);

--- a/board/olimex/a13_olinuxino/board.c
+++ b/board/olimex/a13_olinuxino/board.c
@@ -62,11 +62,11 @@ int show_board_info(void)
 	name = olinuxino_get_board_name();
 
 	olinuxino_get_board_revision(rev);
-	printf("%-7s%s Rev.%s", "ID:", name, rev);
+	printf("%-7s%s Rev.%s\n", "ID:", name, rev);
 
 	return 0;
 }
-#endif
+#endif /* CONFIG_DISPLAY_BOARDINFO  */
 
 #ifdef CONFIG_BOARD_LATE_INIT
 int board_late_init(void)

--- a/board/olimex/a20_olinuxino/board.c
+++ b/board/olimex/a20_olinuxino/board.c
@@ -190,6 +190,7 @@ const char *env_fat_get_dev_part(void)
 }
 #endif /* CONFIG_ENV_IS_IN_FAT */
 
+#if defined(CONFIG_ENV_IS_IN_EXT4) && defined(CONFIG_ENV_IS_IN_FAT)
 enum env_location env_get_location(enum env_operation op, int prio)
 {
 	switch (prio) {
@@ -203,3 +204,4 @@ enum env_location env_get_location(enum env_operation op, int prio)
 
 	return ENVL_UNKNOWN;
 }
+#endif

--- a/board/olimex/common/sunxi/board.c
+++ b/board/olimex/common/sunxi/board.c
@@ -727,6 +727,23 @@ static void parse_spl_header(const uint32_t spl_addr)
 	env_set_hex("fel_scriptaddr", spl->fel_script_address);
 }
 
+
+#if	defined(CONFIG_TARGET_A10_OLINUXINO) || defined(CONFIG_TARGET_A13_OLINUXINO) || \
+	defined(CONFIG_TARGET_A20_OLINUXINO) || defined(CONFIG_TARGET_A64_OLINUXINO)
+static void set_fdtfile(void)
+{
+	const char *fdtname;
+	char fdtfile[68];
+
+	fdtname = olinuxino_get_board_fdt();
+	if (!fdtname[0])
+		return;
+
+	sprintf(fdtfile, "%s.dtb", fdtname);
+	env_set("fdtfile", fdtfile);
+}
+#endif
+
 /*
  * Note this function gets called multiple times.
  * It must not make any changes to env variables which already exist.
@@ -836,6 +853,11 @@ static void setup_environment(const void *fdt)
 			env_set("serial#", serial_string);
 		}
 	}
+
+#if	defined(CONFIG_TARGET_A10_OLINUXINO) || defined(CONFIG_TARGET_A13_OLINUXINO) || \
+	defined(CONFIG_TARGET_A20_OLINUXINO) || defined(CONFIG_TARGET_A64_OLINUXINO)
+	set_fdtfile();
+#endif
 }
 
 int misc_init_r(void)
@@ -899,7 +921,7 @@ static int olinuxino_load_overlay(void *blob, char *overlay)
 static void olinuxino_load_overlays(void *blob)
 {
 	int ret;
-	char cmd[128];
+	char __maybe_unused cmd[128];
 	char *overlay;
 	void *backup;
 


### PR DESCRIPTION
Here you can find few changes I've made during creation of [ArchLinux ARM package](//github.com/RoEdAl/alarm-olimex/tree/master/uboot-32) from your sources.
Maybe you will find them useful.

----

*oLinuXino A10 Lime* bootlog:
````
U-Boot SPL 2020.01.20200701-1 (Jul 01 2020 - 16:45:04 +0000)
DRAM: 512 MiB
CPU: 912000000Hz, AXI/AHB/APB: 3/2/2
A10-Lime Board no eeprom found!
 Trying to boot from MMC1

U-Boot 2020.01.20200701-1 (Jul 01 2020 - 16:45:04 +0000) Arch Linux ARM

CPU:   Allwinner A10 (SUN4I)
ID:    A10-OLinuXino-Lime
I2C:   ready
DRAM:  512 MiB
MMC:   mmc@1c0f000: 0
In:    serial
Out:   serial
Err:   serial
Net:   eth0: ethernet@1c0b000
starting USB...
Bus usb@1c14000: USB EHCI 1.00
Bus usb@1c14400: USB OHCI 1.0
Bus usb@1c1c000: USB EHCI 1.00
Bus usb@1c1c400: USB OHCI 1.0
scanning bus usb@1c14000 for devices... 1 USB Device(s) found
scanning bus usb@1c14400 for devices... 1 USB Device(s) found
scanning bus usb@1c1c000 for devices... 1 USB Device(s) found
scanning bus usb@1c1c400 for devices... 1 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:
switch to partitions #0, OK
mmc0 is current device
Scanning mmc 0:1...
Found U-Boot script /boot.scr
2460 bytes read in 2 ms (1.2 MiB/s)
## Executing script at 43100000
7281760 bytes read in 637 ms (10.9 MiB/s)
22070 bytes read in 5 ms (4.2 MiB/s)
7772007 bytes read in 683 ms (10.9 MiB/s)
## Flattened Device Tree blob at 43000000
   Booting using the fdt blob at 0x43000000
EHCI failed to shut down host controller.
   Loading Ramdisk to 49896000, end 49fff767 ... OK
   Loading Device Tree to 4988d000, end 49895635 ... OK

Starting kernel ...
````

----

*oLinuXino A20 Lime2* bootlog:
````
U-Boot SPL 2020.01.20200701-1 (Jul 01 2020 - 16:45:04 +0000)
DRAM: 1024 MiB
CPU: 912000000Hz, AXI/AHB/APB: 3/2/2
Loading configuration from EEPROM: OK
Verifying data: OK
Trying to boot from MMC1

U-Boot 2020.01.20200701-1 (Jul 01 2020 - 16:45:04 +0000) Arch Linux ARM

CPU:   Allwinner A20 (SUN7I)
ID:    A20-OLinuXino-LIME2 Rev.XX
SN:    XXXXXXXX
MAC:   XX:XX:XX:XX:XX:XX
I2C:   ready
DRAM:  1 GiB
MMC:   mmc@1c0f000: 0, mmc@1c12000: 1
In:    serial
Out:   serial
Err:   serial
Allwinner mUSB OTG (Peripheral)
Net:   eth0: ethernet@1c50000
Warning: usb_ether using MAC address from ROM
, eth1: usb_ether
starting USB...
Bus usb@1c14000: USB EHCI 1.00
Bus usb@1c14400: USB OHCI 1.0
Bus usb@1c1c000: USB EHCI 1.00
Bus usb@1c1c400: USB OHCI 1.0
scanning bus usb@1c14000 for devices... 1 USB Device(s) found
scanning bus usb@1c14400 for devices... 1 USB Device(s) found
scanning bus usb@1c1c000 for devices... 1 USB Device(s) found
scanning bus usb@1c1c400 for devices... 1 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:
switch to partitions #0, OK
mmc0 is current device
Scanning mmc 0:1...
Found U-Boot script /boot.scr
2460 bytes read in 2 ms (1.2 MiB/s)
## Executing script at 43100000
7281760 bytes read in 402 ms (17.3 MiB/s)
28908 bytes read in 4 ms (6.9 MiB/s)
7772007 bytes read in 430 ms (17.2 MiB/s)
## Flattened Device Tree blob at 43000000
   Booting using the fdt blob at 0x43000000
EHCI failed to shut down host controller.
   Loading Ramdisk to 49896000, end 49fff767 ... OK
   Loading Device Tree to 4988b000, end 498950eb ... OK

Starting kernel ...
````